### PR TITLE
fix: require Python >= 3.7, add requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ docker run \
 
 If the config.yaml pushes to S3, specify the credentials by adding `-e S3_ACCESS=<s3-user>` and `-e S3_SECRET=<s3-password>` to the command above.
 
+> [!NOTE]
+> If an error occurs such as:
+> ```
+> Error during unshare(CLONE_NEWUSER): Operation not permitted
+> time="2025-02-06T07:47:00Z" level=error msg="parsing PID \"\": strconv.Atoi: parsing \"\": invalid syntax"
+> time="2025-02-06T07:47:00Z" level=error msg="(Unable to determine exit status)"
+> ```
+> Try adding `--security-opt seccomp=unconfined`.
+
 ## Bare Metal
 
 > [!WARNING]

--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@ The recommended way to run `image-build` is through the container as it avoids a
 
 ## Container
 
-To build an image using the container, you will need to map the config file into the container, as well as the FUSE filesystem device:
+The supported way for running the container is via [Podman](https://podman.io/).
+To build an image using the container, the config file needs to be mapped into the container, as well as the FUSE filesystem device:
 
 ```
-docker run \
+podman run \
   --rm \
   --device /dev/fuse \
   -v /path/to/config.yaml:/home/builder/config.yaml \
@@ -21,15 +22,6 @@ docker run \
 ```
 
 If the config.yaml pushes to S3, specify the credentials by adding `-e S3_ACCESS=<s3-user>` and `-e S3_SECRET=<s3-password>` to the command above.
-
-> [!NOTE]
-> If an error occurs such as:
-> ```
-> Error during unshare(CLONE_NEWUSER): Operation not permitted
-> time="2025-02-06T07:47:00Z" level=error msg="parsing PID \"\": strconv.Atoi: parsing \"\": invalid syntax"
-> time="2025-02-06T07:47:00Z" level=error msg="(Unable to determine exit status)"
-> ```
-> Try adding `--security-opt seccomp=unconfined`.
 
 ## Bare Metal
 
@@ -50,7 +42,7 @@ image-build --config /path/to/config.yaml
 
 From the root of the repository:
 ```
-docker build -t ghcr.io/openchami/image-buildi:latest -f src/dockerfiles/Dockerfile .
+buildah bud -t ghcr.io/openchami/image-buildi:latest -f src/dockerfiles/Dockerfile .
 ```
 
 # Configuration

--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@
 A wrapper around various `buildah` commands that makes creating images in layers easier.
 There are two supported modes at the moment, a "base" type layer and an "ansible" type layer
 
+# Setup
+
+> [!NOTE]
+> Python >= 3.7 is required.
+
+```
+pip install -r requirements.txt
+```
+
 # Base Type layer
 The premise here is very simple. The `image-build` tool builds a base layer by starting a container, then using the provided package manager to install repos and packages. There is limited support for running basic commands inside the container. These settings are provided in a config file and command line options
 

--- a/README.md
+++ b/README.md
@@ -3,16 +3,51 @@
 A wrapper around various `buildah` commands that makes creating images in layers easier.
 There are two supported modes at the moment, a "base" type layer and an "ansible" type layer
 
-# Setup
+# Running
 
-> [!NOTE]
-> Python >= 3.7 is required.
+The recommended way to run `image-build` is through the container as it avoids any Python dependency troubles.
 
+## Container
+
+To build an image using the container, you will need to map the config file into the container, as well as the FUSE filesystem device:
+
+```
+docker run \
+  --rm \
+  --device /dev/fuse \
+  -v /path/to/config.yaml:/home/builder/config.yaml \
+  ghcr.io/openchami/image-build:latest \
+  image-build --config config.yaml
+```
+
+If the config.yaml pushes to S3, specify the credentials by adding `-e S3_ACCESS=<s3-user>` and `-e S3_SECRET=<s3-password>` to the command above.
+
+## Bare Metal
+
+> [!WARNING]
+> Python >= 3.7 is required!
+
+Install the Python package dependencies:
 ```
 pip install -r requirements.txt
 ```
 
-# Base Type layer
+Run the tool:
+```
+image-build --config /path/to/config.yaml
+```
+
+# Building Container
+
+From the root of the repository:
+```
+docker build -t ghcr.io/openchami/image-buildi:latest -f src/dockerfiles/Dockerfile .
+```
+
+# Configuration
+
+## Base Type Layer
+
 The premise here is very simple. The `image-build` tool builds a base layer by starting a container, then using the provided package manager to install repos and packages. There is limited support for running basic commands inside the container. These settings are provided in a config file and command line options
 
 An example config file:
@@ -52,7 +87,8 @@ image-build --name base-os \
 You can then build on top of this base os with a new config file, just point the `--parent` flag at the base os container image
 
 
-# Ansible Type Layer
+## Ansible Type Layer
+
 You can also run an ansible playbook against a buildah container. This type using the Buildah connection plugin in ansible to treat the container as a host.
 ```
 image-build \
@@ -68,15 +104,19 @@ image-build \
 This requires the parent to be setup to run ansible tasks
 
 
-# Publish images
+# Publishing Images
+
 The `image-build` tool can publish the image layers to a few kinds of endpoints
 
 ## S3
+
 using the `--publish-s3 <URL>` option will push to an s3 endpoint defined in an ENV variable: `S3_URL`.
 You can also set the access and secret values with `S3_ACCESS` and `S3_SECRET` respectively
 
 ## Registry
+
 Using the `--publish-registry <URL>` option will push to a docker registry defined in an ENV variable: `REGISTRY_EP`. You can point to a certs directory by setting `REGISTRY_CERTS_DIR`.
 
 ## Local
+
 Using the `--publish-local` option will squash the layer and copy it to a destination defined in `--publish-dest`.

--- a/dockerfiles/dnf/Dockerfile
+++ b/dockerfiles/dnf/Dockerfile
@@ -43,4 +43,4 @@ WORKDIR /home/builder
 
 ENV BUILDAH_ISOLATION=chroot
 
-ENTRYPOINT ["/usr/bin/buildah", "unshare", "bash", "-c"]
+ENTRYPOINT ["/usr/bin/buildah", "unshare"]

--- a/dockerfiles/dnf/Dockerfile.minimal
+++ b/dockerfiles/dnf/Dockerfile.minimal
@@ -44,4 +44,4 @@ RUN python3.11 -m pip install --no-cache-dir --upgrade pip && \
 WORKDIR /home/builder
 
 # Default entrypoint
-ENTRYPOINT ["/usr/bin/buildah", "unshare", "bash", "-c"]
+ENTRYPOINT ["/usr/bin/buildah", "unshare"]

--- a/dockerfiles/zypper/Dockerfile
+++ b/dockerfiles/zypper/Dockerfile
@@ -83,4 +83,4 @@ WORKDIR /home/builder
 
 ENV BUILDAH_ISOLATION=chroot
 
-ENTRYPOINT ["/usr/bin/buildah", "unshare", "bash", "-c"]
+ENTRYPOINT ["/usr/bin/buildah", "unshare"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+ansible
+boto3
+PyYAML

--- a/src/image-build
+++ b/src/image-build
@@ -70,4 +70,8 @@ def main():
         sys.exit(1)
 
 if __name__ == "__main__":
-    main()
+    # Make sure Python >= 3.7 is being used
+    if sys.version_info[0] >= 3 and sys.version_info[1] >= 7:
+        main()
+    else:
+        raise Exception("Python >= 3.7 is required!")


### PR DESCRIPTION
Certain features like process.Popen()'s text= kwarg require Python >= 3.7. Add a runtime check for it.

Also, add a `requirements.txt` and instructions for using it to install all needed Python dependencies.