### PR TITLE
fix: update build.yaml to handle pull request and tag image tagging

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,7 +47,9 @@ jobs:
                 context: .
                 file: dockerfiles/dnf/Dockerfile
                 push: true
-                tags: |
-                  ghcr.io/openchami/image-build:latest
-                  ${{ startsWith(github.ref, 'refs/pull/') && 'ghcr.io/openchami/image-build:latest-prbuild' || '' }}
-                  ${{ startsWith(github.ref, 'refs/tags/') && 'ghcr.io/openchami/image-build:v' }}${{ startsWith(github.ref, 'refs/tags/') && steps.extract_version.outputs.version || '' }}
+                tags: >
+                  ${{ startsWith(github.ref, 'refs/tags/') 
+                      ? 'ghcr.io/openchami/image-build:v' + steps.extract_version.outputs.version 
+                      : (startsWith(github.ref, 'refs/pull/') 
+                          ? 'ghcr.io/openchami/image-build:latest-prbuild' 
+                          : '') }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,36 +16,50 @@ on:
     workflow_dispatch:
 
 jobs:
-    build:
-        runs-on: ubuntu-latest
-        permissions:
-          contents: read
-          packages: write
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@v3
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
-            - name: Log in to GitHub Container Registry
-              uses: docker/login-action@v2
-              with:
-                registry: ghcr.io
-                username: ${{ github.actor }}
-                password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-            - name: Extract version from tag
-              if: startsWith(github.ref, 'refs/tags/')
-              id: extract_version
-              run: echo "::set-output name=version::${GITHUB_REF#refs/tags/}"
+      - name: Extract version from tag
+        if: startsWith(github.ref, 'refs/tags/')
+        id: extract_version
+        run: echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
-            - name: Build and push Docker image
-              uses: docker/build-push-action@v3
-              with:
-                context: .
-                file: dockerfiles/dnf/Dockerfile
-                push: true
-                tags: ${{ startsWith(github.ref, 'refs/tags/') ? 'ghcr.io/openchami/image-build:v' + steps.extract_version.outputs.version : (startsWith(github.ref, 'refs/pull/') ? 'ghcr.io/openchami/image-build:latest-prbuild' : '') }}
-
+      - name: Determine image tag
+        id: set_tag
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            TAG="ghcr.io/openchami/image-build:v${GITHUB_REF#refs/tags/}"
+          elif [[ "${GITHUB_REF}" == refs/pull/* ]]; then
+            TAG="ghcr.io/openchami/image-build:latest-prbuild"
+          else
+            TAG=""
+          fi
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+          echo "Computed tag: ${TAG}"
+      
+      - name: Build and push Docker image
+        # Only run this step if a valid tag is computed
+        if: steps.set_tag.outputs.tag != ''
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: dockerfiles/dnf/Dockerfile
+          push: true
+          tags: ${{ steps.set_tag.outputs.tag }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,7 +49,7 @@ jobs:
           elif [[ "${GITHUB_REF}" == refs/pull/* ]]; then
             TAG="ghcr.io/openchami/image-build:latest-prbuild"
           else
-            TAG=""
+            TAG="test"
           fi
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
           echo "Computed tag: ${TAG}"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,4 +49,4 @@ jobs:
                 push: true
                 tags: |
                   ${{ startsWith(github.ref, 'refs/pull/') && 'ghcr.io/openchami/image-build:latest-prbuild' || 'ghcr.io/openchami/image-build:latest' }}
-                  ${{ startsWith(github.ref, 'refs/tags/') && 'ghcr.io/openchami/image-build:v' + steps.extract_version.outputs.version || '' }}
+                  ${{ startsWith(github.ref, 'refs/tags/') && 'ghcr.io/openchami/image-build:v' }}${{ startsWith(github.ref, 'refs/tags/') && steps.extract_version.outputs.version || '' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,9 +47,5 @@ jobs:
                 context: .
                 file: dockerfiles/dnf/Dockerfile
                 push: true
-                tags: >
-                  ${{ startsWith(github.ref, 'refs/tags/') 
-                      ? 'ghcr.io/openchami/image-build:v' + steps.extract_version.outputs.version 
-                      : (startsWith(github.ref, 'refs/pull/') 
-                          ? 'ghcr.io/openchami/image-build:latest-prbuild' 
-                          : '') }}
+                tags: ${{ startsWith(github.ref, 'refs/tags/') ? 'ghcr.io/openchami/image-build:v' + steps.extract_version.outputs.version : (startsWith(github.ref, 'refs/pull/') ? 'ghcr.io/openchami/image-build:latest-prbuild' : '') }}
+

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,7 +49,7 @@ jobs:
           elif [[ "${GITHUB_REF}" == refs/pull/* ]]; then
             TAG="ghcr.io/openchami/image-build:latest-prbuild"
           else
-            TAG="test"
+            TAG="ghcr.io/openchami/image-build:test"
           fi
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
           echo "Computed tag: ${TAG}"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,5 +48,6 @@ jobs:
                 file: dockerfiles/dnf/Dockerfile
                 push: true
                 tags: |
-                  ${{ startsWith(github.ref, 'refs/pull/') && 'ghcr.io/openchami/image-build:latest-prbuild' || 'ghcr.io/openchami/image-build:latest' }}
+                  ghcr.io/openchami/image-build:latest
+                  ${{ startsWith(github.ref, 'refs/pull/') && 'ghcr.io/openchami/image-build:latest-prbuild' || '' }}
                   ${{ startsWith(github.ref, 'refs/tags/') && 'ghcr.io/openchami/image-build:v' }}${{ startsWith(github.ref, 'refs/tags/') && steps.extract_version.outputs.version || '' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,4 +48,5 @@ jobs:
                 file: dockerfiles/dnf/Dockerfile
                 push: true
                 tags: |
-                  ghcr.io/openchami/image-build:latest
+                  ${{ startsWith(github.ref, 'refs/pull/') && 'ghcr.io/openchami/image-build:latest-prbuild' || 'ghcr.io/openchami/image-build:latest' }}
+                  ${{ startsWith(github.ref, 'refs/tags/') && 'ghcr.io/openchami/image-build:v' + steps.extract_version.outputs.version || '' }}


### PR DESCRIPTION
This pull request includes changes to the `jobs` section in the `.github/workflows/build.yaml` file to enhance the tagging mechanism for Docker images based on the type of Git reference.

Changes to Docker image tagging:

* [`.github/workflows/build.yaml`](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L51-R52): Modified the `tags` field to dynamically assign tags based on whether the Git reference is a pull request or a tag. For pull requests, the tag `ghcr.io/openchami/image-build:latest-prbuild` is used, and for tags, the version-specific tag `ghcr.io/openchami/image-build:v<version>` is used.