### PR TITLE
add dnf module support

### DIFF
--- a/src/image_config.py
+++ b/src/image_config.py
@@ -22,6 +22,9 @@ class ImageConfig:
     def get_options(self):
         return self.config_data.get('options', [])
 
+    def get_modules(self):
+        return self.config_data.get('modules', [])
+
     def get_packages(self):
         return self.config_data.get('packages', [])
 
@@ -44,6 +47,7 @@ if __name__ == "__main__":
     config = ImageConfig("ochami-images/base-configs/base.yaml")
     options = config.get_options()
     repos = config.get_repos()
+    modules = config.get_modules()
     package_groups = config.get_package_groups()
     packages = config.get_packages()
     remove_packages = config.get_remove_packages()

--- a/src/installer.py
+++ b/src/installer.py
@@ -193,7 +193,8 @@ class Installer:
             args.append("--setopt=cachedir="+os.path.join(self.tdir, self.pkg_man, "cache"))
             if proxy != "":
                 args.append("--setopt=proxy="+proxy)
-            args.append("module enable")
+            args.append("module")
+            args.append("enable")
             args.append("-y")
             args.append("--nogpgcheck")
             args.append("--installroot")

--- a/src/installer.py
+++ b/src/installer.py
@@ -176,34 +176,35 @@ class Installer:
             raise Exception("Installing base packages failed")
 
     def install_base_modules(self, modules, registry_loc, proxy):
-        # check if there are packages groups to install
+        # check if there are modules groups to install
         if len(modules) == 0:
             logging.warn("PACKAGE MODULES: no modules passed to install\n")
             return
-
-        logging.info(f"PACKAGE MODULES: Installing these modules to {self.cname}")
-        logging.info("\n".join(modules))
-        args = []
-
-        if self.pkg_man == "zypper":
-            logging.warn("zypper not supported for modules")
-        elif self.pkg_man == "dnf":
-            args.append("--setopt=reposdir="+os.path.join(self.mname, pathmod.sep_strip(registry_loc)))
-            args.append("--setopt=logdir="+os.path.join(self.tdir, self.pkg_man, "log"))
-            args.append("--setopt=cachedir="+os.path.join(self.tdir, self.pkg_man, "cache"))
-            if proxy != "":
-                args.append("--setopt=proxy="+proxy)
-            args.append("module")
-            args.append("enable")
-            args.append("-y")
-            args.append("--nogpgcheck")
-            args.append("--installroot")
-            args.append(self.mname)
-            args.extend(modules)
-
-        rc = cmd([self.pkg_man] + args)
-        if rc == 104:
-            raise Exception("Installing base packages failed")
+        logging.info(f"MODULES: Running these module commands for {self.cname}")
+        for mod_cmd, mod_list in modules.items():
+            logging.info(mod_cmd + ": " + " ".join(mod_list))
+        for mod_cmd, mod_list in modules.items():
+            args = []
+            if self.pkg_man == "zypper":
+                logging.warn("zypper does not support package groups")
+                return
+            elif self.pkg_man == "dnf":
+                args.append("--setopt=reposdir="+os.path.join(self.mname, pathmod.sep_strip(registry_loc)))
+                args.append("--setopt=logdir="+os.path.join(self.tdir, self.pkg_man, "log"))
+                args.append("--setopt=cachedir="+os.path.join(self.tdir, self.pkg_man, "cache"))
+                if proxy != "":
+                    args.append("--setopt=proxy="+proxy)
+                args.append("module")
+                args.append(mod_cmd)
+                args.append("-y")
+                args.append("--nogpgcheck")
+                args.append("--installroot")
+                args.append(self.mname)
+                args.extend(mod_list)
+            rc = cmd([self.pkg_man] + args)
+            if rc != 0:
+                raise Exception("Failed to run module cmd", mod_cmd, ' '.join(mod_list))
+            
 
     def install_base_commands(self, commands):
         # check if there are commands to install

--- a/src/installer.py
+++ b/src/installer.py
@@ -175,6 +175,35 @@ class Installer:
         if rc == 104:
             raise Exception("Installing base packages failed")
 
+    def install_base_modules(self, modules, registry_loc, proxy):
+        # check if there are packages groups to install
+        if len(modules) == 0:
+            logging.warn("PACKAGE MODULES: no modules passed to install\n")
+            return
+
+        logging.info(f"PACKAGE MODULES: Installing these modules to {self.cname}")
+        logging.info("\n".join(modules))
+        args = []
+
+        if self.pkg_man == "zypper":
+            logging.warn("zypper not supported for modules")
+        elif self.pkg_man == "dnf":
+            args.append("--setopt=reposdir="+os.path.join(self.mname, pathmod.sep_strip(registry_loc)))
+            args.append("--setopt=logdir="+os.path.join(self.tdir, self.pkg_man, "log"))
+            args.append("--setopt=cachedir="+os.path.join(self.tdir, self.pkg_man, "cache"))
+            if proxy != "":
+                args.append("--setopt=proxy="+proxy)
+            args.append("module enable")
+            args.append("-y")
+            args.append("--nogpgcheck")
+            args.append("--installroot")
+            args.append(self.mname)
+            args.extend(modules)
+
+        rc = cmd([self.pkg_man] + args)
+        if rc == 104:
+            raise Exception("Installing base packages failed")
+
     def install_base_commands(self, commands):
         # check if there are commands to install
         if len(commands) == 0:

--- a/src/layer.py
+++ b/src/layer.py
@@ -19,7 +19,7 @@ class Layer:
         out.append(line)
         return out
 
-    def _build_base(self, repos, packages, package_groups, remove_packages, commands, copyfiles):
+    def _build_base(self, repos, modules, packages, package_groups, remove_packages, commands, copyfiles):
         dt_string = datetime.now().strftime("%Y%m%d%H%M%S")
 
         # container and mount name
@@ -69,6 +69,8 @@ class Layer:
 
         # Install Packages
         try:
+            # Enable modules
+            inst.install_base_modules(modules, repo_dest, self.args['proxy'])
             # Base Package Groups
             inst.install_base_package_groups(package_groups, repo_dest, self.args['proxy'])
             # Packages
@@ -143,13 +145,14 @@ class Layer:
         if self.args['layer_type'] == "base":
             
             repos = self.image_config.get_repos()
+            modules = self.image_config.get_modules()
             packages = self.image_config.get_packages()
             package_groups = self.image_config.get_package_groups()
             remove_packages = self.image_config.get_remove_packages()
             commands = self.image_config.get_commands()
             copyfiles = self.image_config.get_copy_files()
 
-            cname = self._build_base(repos, packages, package_groups, remove_packages, commands, copyfiles)
+            cname = self._build_base(repos, modules, packages, package_groups, remove_packages, commands, copyfiles)
         elif self.args['layer_type'] == "ansible":
             layer_name = self.args['name']
             print("Layer_Name =", layer_name)


### PR DESCRIPTION
Adds support for DNF modules by adding a new key in the config files:
```
modules:
   enable:
     - list of modules to enable
   install:
     - list of modules to install
   remove:
     - list of modules to install
```
You can use any module subcommand, the tool will not check to make sure it is valid before attempting to run it.

Test file (dump it in `tests/module_test.yaml`):
```
options:
  layer_type: 'base'
  name: 'test'
  publish_tags: 'v1'
  pkg_manager: 'dnf'
  parent: 'scratch'
  publish_local: true

repos:
  - alias: 'Rocky_9_BaseOS'
    url: 'https://dl.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/'
    gpg: 'https://dl.rockylinux.org/pub/rocky/RPM-GPG-KEY-Rocky-9'
  - alias: 'Rocky_9_AppStream'
    url: 'https://dl.rockylinux.org/pub/rocky/9/AppStream/x86_64/os/'
    gpg: 'https://dl.rockylinux.org/pub/rocky/RPM-GPG-KEY-Rocky-9'

modules:
  enable: 
    - 'nodejs:18'
  install:
    - 'nodejs'
```

Try it out:
```
podman run --device /dev/fuse   -it   --name image-builder   --rm -v $PWD/tests:/data ghcr.io/openchami/image-build:test  image-build --log-level INFO --config /data/module_test.yaml
```