### PR TITLE
Added OpenSCAP functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,21 @@ options:
   s3_prefix: 'compute/base/'
   s3_bucket: 'boot-images'
 
+  # Flags available pertaining to OpenSCAP
+  # Install openscap-utils scap-security-guide bzip2 to image
+  #install_scap: true
+  # Run a SCAP scan using the xccdf option. Use this if a SCAP scan is desired.
+  # (Required if using)
+  # - the file path to xccdf xml - specify with the
+  #   benchmark_path key
+  # - profile selection - depends on xml specify with profile key
+  #scap_benchmark: true
+  # Run an OVAL evaluation
+  # (Required if using)
+  # - Link of URL to latest OVAL available for Linux distribution - specify
+  #   with oval_url key 
+  #oval_eval: true
+
 # Package repositories to add. This example uses YUM/DNF repositories.
 repos:
   - alias: 'rocky-baseos'
@@ -122,6 +137,28 @@ packages:
 # control command verbosity. By default, it is 'INFO'.
 cmds:
   - cmd: 'echo hello'
+
+# OpenSCAP options to use with scap_benchmark or oval_eval. Each OpenSCAP 
+# command gets passed to the shell. By default, the results from OpenSCAP will be saved 
+# /root/ inside of the container built.
+# 
+# The xccdf or Extensible Configuration Checklist Description Format, is a 
+# language used to describe security checklists and benchmarks. The xml for 
+# SCAP benchmarks is specific to each Linux distribution, and it is 
+# typically, available via scap-security-guide package. Each xml will have profiles 
+# associated with it. Available profiles can be checked with 'oscap info <path to xml> 
+# Not every Linux distro is going to provide a out of box ready xccdf xml it may need to 
+# be customized
+# 
+# The OVAL or Open Vulnerability Assessment Language is a language used to 
+# standardize the representation of information about system security states. In 
+# short it gives info on if packages on the image have CVEs (Common Vulnerabilities and 
+# Exposures) associated with them. Not every Linux distro is going to have a OVAL 
+# available for download 
+#openscap:
+#  - profile: "xccdf_org.ssgproject.content_profile_stig"
+#  - benchmark_path: "/usr/share/xml/scap/ssg/content/ssg-rl9-ds.xml"
+#  - oval_url: "<Rocky Linux OVAL .bz2 URL>"
 ```
 
 Then you can use this config file to build a "base" layer (make sure the `S3_ACCESS` and `S3_SECRET` environment variables are set to the S3 credentials if being used):
@@ -284,3 +321,4 @@ The labels will be visible in the output under the `Labels` section. These label
 - Build information
 - Compliance requirements
 - Image identification and organization
+

--- a/src/arguments.py
+++ b/src/arguments.py
@@ -64,6 +64,10 @@ def process_args(terminal_args, config_options):
     processed_args['registry_opts_pull'] = terminal_args.registry_opts_pull or config_options.get('registry_opts_pull', [])
 
     processed_args['publish_tags'] = terminal_args.publish_tags or config_options.get('publish_tags',['latest'])
+    
+    processed_args['scap_benchmark'] = terminal_args.scap_benchmark or config_options.get('scap_benchmark', False)
+    processed_args['oval_eval'] = terminal_args.oval_eval or config_options.get('oval_eval', False)
+    processed_args['install_scap'] = terminal_args.install_scap or config_options.get('install_scap', False)
 
     # If no publish options were passed in either the CLI or the config file, store locally.
     if not (processed_args['publish_s3']

--- a/src/image-build
+++ b/src/image-build
@@ -39,7 +39,11 @@ def main():
     parser.add_argument('--vars', dest='vars', action='store', nargs='+', type=str, default=[], help='List of variables')
     parser.add_argument('--pb', type=str)
     parser.add_argument('--inventory', nargs='+', default=[], help='Inventory list')
-    
+    parser.add_argument('--scap-benchmark', dest="scap_benchmark", action='store_true', required=False)
+    parser.add_argument('--oval-eval', dest="oval_eval", action='store_true', required=False)
+    parser.add_argument('--install-scap', dest="install_scap", action='store_true', required=False)
+
+
     try:
         terminal_args = parser.parse_args()
 

--- a/src/image_config.py
+++ b/src/image_config.py
@@ -43,6 +43,10 @@ class ImageConfig:
     def get_repos(self):
         return self.config_data.get('repos', [])
 
+    def get_oscap_options(self):
+        return self.config_data.get('openscap', [])
+
+
 if __name__ == "__main__":
     config = ImageConfig("ochami-images/base-configs/base.yaml")
     options = config.get_options()
@@ -53,6 +57,7 @@ if __name__ == "__main__":
     remove_packages = config.get_remove_packages()
     commands = config.get_commands()
     copyfiles = config.get_copy_files()
+    oscap_options = config.get_oscap_options()
 
     print("Options: ", options)
     print("Repos: ", repos)
@@ -60,3 +65,4 @@ if __name__ == "__main__":
     print("Packages: ", packages)
     print("Remove Packages: ", remove_packages)
     print("Commands: ", commands)
+    print("OpenSCAP Options: ", oscap_options)

--- a/src/oscap.py
+++ b/src/oscap.py
@@ -1,0 +1,114 @@
+import logging
+from utils import cmd
+
+class Oscap:
+    def __init__(self, oscap_options, args, inst):
+        oscap_config = self._get_oscap_filepaths()
+        for i in oscap_options:
+            oscap_config.update(i)
+        self.oscap_config = oscap_config
+        self.args = args
+        self.inst = inst
+        self.logger = logging.getLogger(__name__)
+
+    def check_install(self):
+        check_install = self._check_scap_install() 
+        commands = [
+            {'cmd': check_install, 'loglevel': 'DEBUG'},
+        ]
+        try:
+            self.inst.install_base_commands(commands)
+        except Exception as e:
+            self.logger.error(f"openscap not found - Try installing the following: openscap-utils scap-security-guide or passing in --install-scap to image-builder: {e}")
+            cmd(["buildah","rm"] + [cname])
+            sys.exit("Exiting now")
+        except KeyboardInterrupt:
+            self.logger.error(f"Keyboard Interrupt")
+            cmd(["buildah","rm"] + [cname])
+            sys.exit("Exiting now ...") 
+
+    def install_scap(self):
+        if self.args['pkg_man'] == "zypper":
+            repo_dest = "/etc/zypp/repos.d"
+        elif self.args['pkg_man'] == "dnf":
+            repo_dest = "/etc/yum.repos.d"
+        else:
+            self.logger.error("unsupported package manager")
+        scap_packages = self._generate_scap_package_list()
+        try:
+            self.inst.install_base_packages(scap_packages, repo_dest, self.args['proxy'])
+        except Exception as e:
+            self.logger.error(f"Issues installing openscap with repos available - typically available via distro appstream repo: {e}")
+            cmd(["buildah","rm"] + [cname])
+            sys.exit("Exiting now")
+        except KeyboardInterrupt:
+            self.logger.error(f"Keyboard Interrupt")
+            cmd(["buildah","rm"] + [cname])
+            sys.exit("Exiting now ...")
+
+
+    def run_oval_eval(self):
+        obtain_oval_cmd = self._generate_obtain_oval_cmd()
+        evaluation_oval = self._generate_evaluate_oval()
+
+        commands = [
+            {'cmd': obtain_oval_cmd, 'loglevel': 'DEBUG'},
+            {'cmd': evaluation_oval, 'loglevel': 'DEBUG'}
+        ]
+        try:
+            self.inst.install_base_commands(commands)
+        except Exception as e:
+            self.logger.error("Error with SCAP OVAL eval - Please check the logs: {e}")
+            cmd(["buildah","rm"] + [cname])
+            sys.exit("Exiting now")
+        except KeyboardInterrupt:
+            self.logger.error(f"Keyboard Interrupt")
+            cmd(["buildah","rm"] + [cname])
+            sys.exit("Exiting now ...")
+
+    def run_oscap(self):
+        evaluation_cmd = self._generate_evaluate_cmd()
+        remediation_cmd = self._generate_remediate_cmd()
+
+        commands = [
+            {'cmd': evaluation_cmd, 'loglevel': 'DEBUG'},
+            {'cmd': remediation_cmd, 'loglevel': 'DEBUG'}
+        ]
+        try:
+            self.inst.install_base_commands(commands)
+        except Exception as e:
+            self.logger.error("Error with SCAP benchmark and generation of remediation script - please check the logs: {e}")
+            cmd(["buildah","rm"] + [cname])
+            sys.exit("Exiting now")
+        except KeyboardInterrupt:
+            self.logger.error(f"Keyboard Interrupt")
+            cmd(["buildah","rm"] + [cname])
+            sys.exit("Exiting now ...")
+
+
+    def _get_oscap_filepaths(self):
+        return {
+            'results_path': "/root/scan.xml",
+            'remediate_path': "/root/remediate.sh",
+            'oval_xml': "/root/oval.xml",
+            'oval_path': "/root/vulnerabilities.xml",
+        }
+
+    def _check_scap_install(self):
+        return f"oscap --version"
+
+    def _generate_scap_package_list(self):
+        return ["openscap-utils",  "scap-security-guide", "bzip2"]
+
+    def _generate_evaluate_cmd(self):
+        return f"oscap xccdf eval --fetch-remote-resources --profile {self.oscap_config['profile']} --results {self.oscap_config['results_path']} {self.oscap_config['benchmark_path']} || true"
+
+    def _generate_evaluate_oval(self):
+        return f"oscap oval eval --report {self.oscap_config['oval_path']} {self.oscap_config['oval_xml']} || true"
+
+    def _generate_obtain_oval_cmd(self):
+        return f"curl -L -o - {self.oscap_config['oval_url']} | bzip2 --decompress > {self.oscap_config['oval_xml']}"
+
+    def _generate_remediate_cmd(self):
+        return f"oscap xccdf generate fix --output {self.oscap_config['remediate_path']} --profile {self.oscap_config['profile']} {self.oscap_config['results_path']}"
+


### PR DESCRIPTION
# What's been changed/added
- Added oscap.py module
- Added options for OpenSCAP to parser in image-build
- Added get_oscap_options() to image_config.py and display options passed
- Handle OpenSCAP arguments from parser and config_options.get() in arguments.py
- Added openscap_options to _build_base() in layer.py 
- If a OpenSCAP flag or key is passed oscap object is created in layer.py. 

# Background
- OpenSCAP: is an open-source framework primarily used for automated security auditing and compliance checking
- xccdf or Extensible Configuration Checklist Description Format: is a language used to describe security checklists and benchmarks. The xml for SCAP benchmarks is specific to each Linux distribution and it is typically available via scap-security-guide package. Each xml will have profiles associated with it. Available profiles can be checked with 'oscap info "path to xml"'. Not every Linux distro is going to provide a out of box ready xccdf xml it may need to be customized
- OVAL or Open Vulnerability Assessment Language: Is a language used to standardize the representation of information about system security states. In short it gives info on if packages on the image have CVEs (Common Vulnerabilities and Exposures) associated with them. Not every Linux distro is going to have a OVAL available for download

# Why this change is necessary
OpenCHAMI places a emphasis on safeguarding HPC. By adding OpenSCAP to OpenCHAMI the focus of cluster admins can be on evaluation and the remediation of applicable controls from a Security Technical Implementation Guide and Open Vulnerability and Assessment Language. By adding OpenSCAP as tool available to OpenCHAMI's Image Builder it ensures security is considered from the beginning of an image lifecycle and minimizes manual effort. 

# How to test

## Alma
**alma.yaml**
```
options:
  layer_type: 'base'
  name: 'alma8-base'
  publish_tags: '8'
  pkg_manager: 'dnf'
  parent: 'docker.io/library/almalinux:8.8'
  publish_registry: '<CHANGEME>'
  registry_opts_push:
   - '--tls-verify=false'
  install_scap: true
  scap_benchmark: true
  oval_eval: true

openscap:
  - profile: "xccdf_org.ssgproject.content_profile_stig"
  - benchmark_path: "/usr/share/xml/scap/ssg/content/ssg-almalinux8-ds.xml"
  - oval_url: "https://security.almalinux.org/oval/org.almalinux.alsa-8.xml.bz2"
```
Copy this yaml. I saved mine to a directory called testcases. In this example the packages needed for OpenSCAP are passed into packages.

### Command used to run:
```
podman run --rm --device /dev/fuse --network host -v ./testcases/alma.yaml:/home/builder/config.yaml -v ./src/:/usr/local/bin ghcr.io/openchami/image-build:latest image-build --config config.yaml --log-level DEBUG
```
After image build finishes scan.xml and remediation.sh will output to /root/ in container 

### After image build finishes remediation.xml, scan.xml, and remediation.sh will output to /root/ in the container
```
# Check if files exist - using podman run
[root@8b9998a15681 /]# cd /root
[root@8b9998a15681 ~]# ls -altr
total 6831
-rw-r--r--. 1 root root      129 Aug 12  2018 .tcshrc
-rw-r--r--. 1 root root      100 Aug 12  2018 .cshrc
-rw-r--r--. 1 root root      176 Aug 12  2018 .bashrc
-rw-r--r--. 1 root root      176 Aug 12  2018 .bash_profile
-rw-r--r--. 1 root root       18 Aug 12  2018 .bash_logout
-rw-r--r--. 1 root root 18068115 Jul  9 17:38 scan.xml
-rwx------. 1 root root  1418965 Jul  9 17:38 remediate.sh
-rw-r--r--. 1 root root 30651705 Jul  9 17:38 oval.xml
-rw-r--r--. 1 root root  1556050 Jul  9 17:39 vulnerabilities.xml
dr-xr-x---. 1 root root        6 Jul  9 17:39 .
dr-xr-xr-x. 1 root root        3 Jul  9 17:49 ..
```
### Copy files
```
sh-5.1$ podman cp 8b9998a15681:/root/ .
```
### Convert scan.xml to html format if desired
```
oscap xccdf generate report 'scan.xml' > scan.html
```
### Example of scan.html
<img width="2062" height="1676" alt="image" src="https://github.com/user-attachments/assets/33738786-958e-406e-be67-bdc461a7b1ab" />

### Remediate script (remediate.sh) 
```
#!/usr/bin/env bash
###############################################################################
#
# Bash Remediation Script for DISA STIG for Red Hat Enterprise Linux 8
```
# OVAL eval (vulnerabilities.xml)
![image](https://github.com/user-attachments/assets/9a034a8c-4a24-4e95-aaea-4af946639a72)

## Rocky 
**rocky.yaml**
```
options:
  layer_type: 'base'
  name: 'rocky-base'
  publish_tags: '9'
  pkg_manager: 'dnf'
  parent: 'scratch'
  publish_registry: '<CHANGEME>'
  registry_opts_push:
    - '--tls-verify=false'

repos:
  - alias: 'Rocky_9_BaseOS'
    url: 'https://dl.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/'
    gpg: 'https://dl.rockylinux.org/pub/rocky/RPM-GPG-KEY-Rocky-9'
  - alias: 'Rocky_9_AppStream'
    url: 'https://dl.rockylinux.org/pub/rocky/9/AppStream/x86_64/os/'
    gpg: 'https://dl.rockylinux.org/pub/rocky/RPM-GPG-KEY-Rocky-9'

package_groups:
  - 'Minimal Install'
  - 'Development Tools'

packages:
  - kernel
  - wget
  - dracut-live
  - cloud-init
  - chrony
  - rsyslog
  - sudo
  - openscap-utils
  - scap-security-guide
  - bzip2

cmds:
  - cmd: 'dracut --add "dmsquash-live livenet network-manager" --kver $(basename /lib/modules/*) -N -f --logfile /tmp/dracut.log 2>/dev/null'
    loglevel: INFO
  - cmd: 'echo DRACUT LOG:; cat /tmp/dracut.log'
    loglevel: INFO

openscap:
  - profile: "xccdf_org.ssgproject.content_profile_stig"
  - benchmark_path: "/usr/share/xml/scap/ssg/content/ssg-rl9-ds.xml"
```
Rocky at this time isn't supporting consistent OVAL files - last updated in March 2025 and the definitions are broken (https://dl.rockylinux.org/pub/oval/) hence why only a SCAP benchmark is ran. 

Command used:
```
podman run --rm --device /dev/fuse --network host -v ./testcases/rocky.yaml:/home/builder/config.yaml -v ./src/:/usr/local/bin ghcr.io/openchami/image-build:latest image-build --config config.yaml --log-level DEBUG --scap-benchmark
```

## sle15
**Dockerfile** 
Build builder container with the following Dockerfile
```
FROM registry.suse.com/suse/sle15:15.5

RUN  touch /run/zypp.pid && \
     chmod 0666 /run/zypp.pid


RUN rpm -e container-suseconnect
RUN rm -f /etc/containers/mounts.conf

COPY src/* /usr/local/bin/
RUN chmod 0755 /usr/local/bin/*

# Install some useful packages
RUN zypper clean --all
RUN zypper -n --gpg-auto-import-keys ref -f -d
RUN zypper -n update
RUN zypper -n --no-gpg-checks install \
        bash \
        vim \
        git \
        curl \
        wget \
        buildah \
        python311 \
        python311-pip \
        fuse-overlayfs \
        tar \
        squashfs \
        libcap-progs \
        rsync \
        unzip

# Python3.9 fixes
RUN ln -s /usr/bin/python3.11 /usr/bin/python3

RUN rm -f /etc/containers/mounts.conf

COPY requirements.txt /
RUN pip3.11 install -r /requirements.txt

RUN echo "%_netsharedpath /dev" >> /etc/rpm/macros

# Allow non-root to run buildah commands
RUN setcap cap_setuid=ep "$(command -v newuidmap)" && \
    setcap cap_setgid=ep "$(command -v newgidmap)" &&\
    chmod 0755 "$(command -v newuidmap)" && \
    chmod 0755 "$(command -v newgidmap)" && \
    echo "builder:2000:50000" > /etc/subuid && \
    echo "builder:2000:50000" > /etc/subgid

# Create local user for rootless image builds
RUN useradd --uid 1002 builder && \
    mkdir -p /home/builder && \
    chown -R builder /home/builder

# Make localuser the default user when running container
USER builder
WORKDIR /home/builder

ENV BUILDAH_ISOLATION=chroot

ENTRYPOINT ["/usr/bin/buildah", "unshare"]
```
Build container with buildah:
```
buildah bud -t image-build-zypper -f <path to Dockerfile> .
```

**suse.yaml**
```
options:
  layer_type: 'base'
  name: 'suse'
  publish_tags: '15'
  pkg_manager: 'zypper'
  parent: 'registry.suse.com/suse/sle15:15.5'
  publish_registry: '<CHANGEME>'
  registry_opts_push:
    - '--tls-verify=false'
  scap_benchmark: true
  oval_eval: true
  install_scap: true

openscap:
  - profile: "xccdf_org.ssgproject.content_profile_stig"
  - benchmark_path: "/usr/share/xml/scap/ssg/content/ssg-sle15-ds.xml"
  - oval_url: "https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.15.xml.bz2"
```

Command used: 
```
podman run --rm --device /dev/fuse --network host -v ./testcases/suse.yaml:/home/builder/config.yaml -v ./src/:/usr/local/bin localhost/image-build-zypper:latest image-build --config config.yaml --log-level DEBUG
```

# Additional sources:
https://www.open-scap.org/
https://public.cyber.mil/stigs/scap/
https://csrc.nist.gov/projects/security-content-automation-protocol