### PR TITLE
ci: add arm64 container builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2


### PR DESCRIPTION
Add 64-bit ARM container builds to GHCR.

This adds ARM64 containers to image-builder releases and nothing else. Testing and feedback are appreciated.