### PR TITLE
Allow setting additional DNF arguments in config or cmdline

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ options:
 
   # Distribution flavor of image.
   pkg_manager: 'dnf'
+  # DNF options to use
+  dnf_options:
+    - 'gpgcheck=0'
+    - 'keepcache=1'
 
   # Starting filesystem of image. 'scratch' means to start with a blank
   # filesystem. Currently, only OCI images can be used as parents. In

--- a/src/arguments.py
+++ b/src/arguments.py
@@ -69,6 +69,7 @@ def process_args(terminal_args, config_options):
     processed_args['scap_benchmark'] = terminal_args.scap_benchmark or config_options.get('scap_benchmark', False)
     processed_args['oval_eval'] = terminal_args.oval_eval or config_options.get('oval_eval', False)
     processed_args['install_scap'] = terminal_args.install_scap or config_options.get('install_scap', False)
+    processed_args['dnf_options'] = terminal_args.dnf_options or config_options.get('dnf_options', [])
 
     # If no publish options were passed in either the CLI or the config file, store locally.
     if not (processed_args['publish_s3']

--- a/src/image-build
+++ b/src/image-build
@@ -43,6 +43,7 @@ def main():
     parser.add_argument('--scap-benchmark', dest="scap_benchmark", action='store_true', required=False)
     parser.add_argument('--oval-eval', dest="oval_eval", action='store_true', required=False)
     parser.add_argument('--install-scap', dest="install_scap", action='store_true', required=False)
+    parser.add_argument('--dnf-options', dest="dnf_options", action='store', nargs='+', type=str, default=[], required=False, help='List of dnf options')
 
 
     try:


### PR DESCRIPTION
## Pull Request Template

Thank you for your contribution! Please ensure the following before submitting:

### Checklist

- [ ] My code follows the style guidelines of this project  
- [ ] I have added/updated comments where needed  
- [ ] I have added tests that prove my fix is effective or my feature works  
- [ ] I have run `make test` (or equivalent) locally and all tests pass  
- [ ] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [ ] **REUSE Compliance**:  
  - [ ] Each new/modified source file has SPDX copyright and license headers  
  - [ ] Any non-commentable files include a `<filename>.license` sidecar  
  - [ ] All referenced licenses are present in the `LICENSES/` directory  

### Description
Some users have requested adding additional dnf options. Now they can add the dnf options they desire themselves! 
It can be done either in the config or via the command line:
```YAML
dnf_options:
  - 'gpgcheck=0'
  - 'keepcache=1'
```
or
```BASH
--dnf-options gpgcheck=0 keepcache=1
```
I will make it more robust in my next few commits just wanted to put it out here in case anyone was interested in taking a look.

### Type of Change

- [ ] Bug fix  
- [X] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
